### PR TITLE
pass a command to run.sh

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ ARG GROUP_ID=1000
 ENV DB_LOCATION="/home/${USER_NAME}/db"
 ENV PATH=$PATH:"/home/${USER_NAME}}/.local/bin"
 ENV PATH="/opt/blender:${PATH}"
+ENV PATH="/opt/blender:${PATH}"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgl1-mesa-dev \
@@ -77,4 +78,12 @@ RUN git clone --branch $ROMISCAN_BRANCH https://github.com/romi/romiscan && \
 
 EXPOSE 9001
 
+# For interactive shell
 RUN echo "conda activate lpyEnv" >> ~/.bashrc
+
+# For login shell, used in run.sh when passing a script as argument
+RUN echo "conda activate lpyEnv" >> ~/.profile
+RUN echo "export PATH=\$PATH:/opt/blender" >> ~/.profile
+RUN echo "export LD_LIBRARY_PATH=/opt/blender/lib" >> ~/.profile
+
+


### PR DESCRIPTION
close #25 

- run.sh now accepts a command line as argument. This command will be executed by the docker image. Use -c "shell command" when calling run.sh.
- the Dockerfile has been updated to export the environment variables (PATH, LD_LIBRARY_PATH) and initialize the conda environment when a command is executed. 

The run.sh script requests docker to start bash as the startup application. The script passes the command line to execute as an argument. However, in this case, bash creates a non-interactive shell and skips to loading of ~/.bashrc. I've added the -l flag to the bash arguments ("docker run ... bash -l ...) to requests the creation of a login shell. In that case, bash will load the ~/.profile file that also contains the environment variable and conda activate line.

This may not be the ideal way of handling, yet, but it should be break any existing script or work methods.