### PR TITLE
Copy local files in docker i.o. git clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ In this repository, you will find a script `build.sh` in the `docker` directory.
 ```
     git clone https://github.com/romi/romiscanner.git
     cd romiscanner/
-    cd docker/
-    ./build.sh
+    ./docker/build.sh
 ```
 This will create by default a docker image `romiscanner:latest`.
 Inside the docker image, a user is created and named as the one currently used by your system.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -69,10 +69,13 @@ ARG ROMISCANNER_BRANCH=master
 
 RUN git clone --branch $ROMISCAN_BRANCH https://github.com/romi/romiscan && \
     git clone --branch $ROMIDATA_BRANCH https://github.com/romi/romidata && \
-    git clone --branch $ROMISCANNER_BRANCH https://github.com/romi/romiscanner && \
     python -m pip install ./romidata/ --no-cache-dir && \
-    python -m pip install ./romiscanner/ --no-cache-dir && \
     python -m pip install ./romiscan/ --no-cache-dir
+
+COPY --chown=${USER_NAME}:${GROUP_NAME} ./ romiscanner/
+
+RUN cd romiscanner/ && \
+    python -m pip install . --no-cache-dir
 
 
 EXPOSE 9001

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -119,7 +119,7 @@ docker build -t romiscanner:$vtag $docker_opts \
   --build-arg USER_ID=$uid \
   --build-arg GROUP_NAME=$group \
   --build-arg GROUP_ID=$gid \
-  .
+  -f docker/Dockerfile .
 
 # Print docker image build time:
 echo


### PR DESCRIPTION
close #26 

This modification to the docker build process copies the local repository files into the docker image instead of cloning the repository from github. 

The changes reflect the install method of the Dockerfile and the build.sh script in plant-3d-vision/docker/


 