### PR TITLE
ObjFileset defaults to the 'obj' directory in current scan dir

### DIFF
--- a/romiscanner/tasks/scan.py
+++ b/romiscanner/tasks/scan.py
@@ -16,8 +16,9 @@ from romiscanner.vscan import VirtualScanner
 
 
 class ObjFileset(FilesetExists):
-    scan_id = luigi.Parameter()
-    fileset_id = "data"
+    # If no scan_id was provided then you the ID of the active scan.
+    scan_id = luigi.Parameter(default="")
+    fileset_id = luigi.Parameter(default="obj")
 
 
 class HdriFileset(FilesetExists):


### PR DESCRIPTION
close #27 

The ObjFileset task will, by default, check that the 'obj' fileset exists in the currently active scan directory. 

The proposition involves three changes:
- If no 'scan_id' is given, the default active scan will be used. The scan_id can still be set in the configuration file as before.
- The previous default fileset_id has been changed from "data" to "obj"
- This default value of the fileset_id can now be changed in the configuration file (was previously hardcoded)

So if no [ObjFileset] section appears in the configuration file, the fileset <current-scan>/obj will be used.
Otherwise this can be changed in the configuration as follows:

[ObjFileset]
scan_id = "myscan"
fileset_id = "data"
